### PR TITLE
Add cross-platform install/uninstall scripts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,12 @@ CHROMA_PATH=./.chroma_db
 
 # Fireworks API key (used by Qwen agent)
 FIREWORKS_API_KEY=your-api-key-here
+
+# Fireworks model ID (default: DeepSeek V3.1)
+FIREWORKS_MODEL=accounts/fireworks/models/deepseek-v3p1
+
+# API server port
+API_PORT=8000
+
+# Vault indexer interval in minutes
+INDEX_INTERVAL=60

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,287 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Installs obsidian-tools on Windows: Python venv, dependencies, .env, Task Scheduler services.
+.DESCRIPTION
+    Run from the project root: .\install.ps1
+#>
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+# ── Constants ────────────────────────────────────────────────────────────────
+
+$MinMinor = 11
+$MaxMinor = 13
+$PreferredVersion = "3.12"
+$ProjectDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+function Write-Info  { param($msg) Write-Host "==> $msg" -ForegroundColor Cyan }
+function Write-Warn  { param($msg) Write-Host "==> $msg" -ForegroundColor Yellow }
+function Write-Err   { param($msg) Write-Host "==> $msg" -ForegroundColor Red }
+
+function Test-PythonVersion {
+    param([string]$PythonPath)
+    try {
+        $output = & $PythonPath --version 2>&1
+        if ($output -match "Python (\d+)\.(\d+)\.(\d+)") {
+            $minor = [int]$Matches[2]
+            return ($minor -ge $MinMinor -and $minor -le $MaxMinor)
+        }
+    } catch {}
+    return $false
+}
+
+function Find-CompatiblePython {
+    # Try the py launcher first (most reliable on Windows)
+    foreach ($minor in @(12, 13, 11)) {
+        try {
+            $pyPath = (Get-Command "py" -ErrorAction Stop).Source
+            $testOutput = & py "-3.$minor" --version 2>&1
+            if ($LASTEXITCODE -eq 0) {
+                # py launcher found a matching version; get the real path
+                $realPath = & py "-3.$minor" -c "import sys; print(sys.executable)" 2>&1
+                if ($LASTEXITCODE -eq 0 -and (Test-Path $realPath)) {
+                    return $realPath.Trim()
+                }
+            }
+        } catch {}
+    }
+
+    # Fall back to searching PATH
+    foreach ($cmd in @("python3", "python")) {
+        try {
+            $path = (Get-Command $cmd -ErrorAction Stop).Source
+            if (Test-PythonVersion $path) { return $path }
+        } catch {}
+    }
+
+    return $null
+}
+
+function Read-Prompt {
+    param(
+        [string]$Label,
+        [string]$Default = "",
+        [bool]$Required = $false
+    )
+
+    while ($true) {
+        if ($Default) {
+            $input = Read-Host "==> $Label [$Default]"
+        } else {
+            $input = Read-Host "==> $Label"
+        }
+
+        if (-not $input -and $Default) { $input = $Default }
+
+        if (-not $input -and $Required) {
+            Write-Warn "This value is required."
+            continue
+        }
+        return $input
+    }
+}
+
+function Read-VaultPath {
+    while ($true) {
+        $vaultPath = Read-Host "==> Path to your Obsidian vault"
+        if (-not $vaultPath) {
+            Write-Warn "This value is required."
+        } elseif (-not (Test-Path $vaultPath -PathType Container)) {
+            Write-Warn "Directory not found: $vaultPath"
+        } else {
+            return $vaultPath
+        }
+    }
+}
+
+function Set-EnvValue {
+    param([string]$Key, [string]$Value, [string]$EnvFile)
+
+    $content = Get-Content $EnvFile -Raw
+    $pattern = "(?m)^${Key}=.*$"
+    if ($content -match $pattern) {
+        $content = $content -replace $pattern, "${Key}=${Value}"
+    } else {
+        $content = $content.TrimEnd() + "`n${Key}=${Value}`n"
+    }
+    Set-Content -Path $EnvFile -Value $content -NoNewline
+}
+
+# ── Service installation ────────────────────────────────────────────────────
+
+function Install-ScheduledTasks {
+    param(
+        [string]$VenvPython,
+        [string]$IntervalMin
+    )
+
+    Write-Info "Installing Task Scheduler tasks..."
+
+    $templateDir = Join-Path $ProjectDir "services\taskscheduler"
+    $tasks = @(
+        @{ Name = "ObsidianToolsAPI";     File = "obsidian-tools-api.xml" },
+        @{ Name = "ObsidianToolsIndexer"; File = "obsidian-tools-indexer.xml" }
+    )
+
+    foreach ($task in $tasks) {
+        $templatePath = Join-Path $templateDir $task.File
+        $xml = Get-Content $templatePath -Raw
+
+        $xml = $xml -replace "__VENV_PYTHON__", $VenvPython
+        $xml = $xml -replace "__PROJECT_DIR__", $ProjectDir
+        $xml = $xml -replace "__INDEX_INTERVAL__", $IntervalMin
+
+        # Write to temp file for registration
+        $tempFile = Join-Path $env:TEMP $task.File
+        Set-Content -Path $tempFile -Value $xml -Encoding Unicode
+
+        # Unregister if exists
+        try { Unregister-ScheduledTask -TaskName $task.Name -Confirm:$false -ErrorAction Stop } catch {}
+
+        Register-ScheduledTask -TaskName $task.Name -Xml $xml | Out-Null
+        Remove-Item $tempFile -ErrorAction SilentlyContinue
+
+        Write-Host "  Registered: $($task.Name)"
+    }
+}
+
+# ── Main ────────────────────────────────────────────────────────────────────
+
+function Main {
+    Write-Host ""
+    Write-Host "  Obsidian Tools Installer"
+    Write-Host "  ========================"
+    Write-Host ""
+
+    Write-Info "Detected OS: Windows"
+
+    # ── Step 1: Find Python ──────────────────────────────────────────────
+
+    Write-Info "Looking for a compatible Python (3.${MinMinor}-3.${MaxMinor})..."
+    $pythonPath = Find-CompatiblePython
+
+    if (-not $pythonPath) {
+        Write-Err "No compatible Python (3.${MinMinor}-3.${MaxMinor}) found."
+        Write-Host ""
+        Write-Host "  Download Python $PreferredVersion from: https://www.python.org/downloads/"
+        Write-Host "  Make sure to check 'Add Python to PATH' during installation."
+        Write-Host ""
+        exit 1
+    }
+
+    $pyVersion = & $pythonPath --version 2>&1
+    Write-Info "Found: $pythonPath ($pyVersion)"
+
+    # ── Step 2: Create virtual environment ───────────────────────────────
+
+    $venvPython = Join-Path $ProjectDir ".venv\Scripts\python.exe"
+
+    if (Test-Path $venvPython) {
+        if (Test-PythonVersion $venvPython) {
+            $venvVersion = & $venvPython --version 2>&1
+            Write-Info "Existing venv is compatible ($venvVersion), keeping it."
+        } else {
+            Write-Warn "Existing venv uses an incompatible Python, recreating..."
+            Remove-Item (Join-Path $ProjectDir ".venv") -Recurse -Force
+            & $pythonPath -m venv (Join-Path $ProjectDir ".venv")
+            Write-Info "Created virtual environment."
+        }
+    } else {
+        & $pythonPath -m venv (Join-Path $ProjectDir ".venv")
+        Write-Info "Created virtual environment."
+    }
+
+    # ── Step 3: Install dependencies ─────────────────────────────────────
+
+    $venvPip = Join-Path $ProjectDir ".venv\Scripts\pip.exe"
+
+    Write-Info "Installing Python dependencies..."
+    & $venvPip install --upgrade pip --quiet
+    & $venvPip install -r (Join-Path $ProjectDir "requirements.txt") --quiet
+    Write-Info "Dependencies installed."
+
+    # ── Step 4: Configure .env ───────────────────────────────────────────
+
+    $envFile = Join-Path $ProjectDir ".env"
+    $envExample = Join-Path $ProjectDir ".env.example"
+
+    if (-not (Test-Path $envFile)) {
+        Copy-Item $envExample $envFile
+        Write-Info "Created .env from .env.example"
+    } else {
+        Write-Info "Existing .env found, updating values."
+    }
+
+    Write-Host ""
+    Write-Info "Configure your environment:"
+    Write-Host ""
+
+    $apiKey         = Read-Prompt "Fireworks API key" -Required $true
+    $fireworksModel = Read-Prompt "Fireworks model (default: DeepSeek V3.1)" -Default "accounts/fireworks/models/deepseek-v3p1"
+    $vaultPath      = Read-VaultPath
+    $chromaPath     = Read-Prompt "ChromaDB path" -Default "./.chroma_db"
+    $apiPort        = Read-Prompt "API server port" -Default "8000"
+    $indexInterval  = Read-Prompt "Index interval (minutes)" -Default "60"
+
+    Set-EnvValue "FIREWORKS_API_KEY" $apiKey $envFile
+    Set-EnvValue "FIREWORKS_MODEL" $fireworksModel $envFile
+    Set-EnvValue "VAULT_PATH" $vaultPath $envFile
+    Set-EnvValue "CHROMA_PATH" $chromaPath $envFile
+    Set-EnvValue "API_PORT" $apiPort $envFile
+    Set-EnvValue "INDEX_INTERVAL" $indexInterval $envFile
+
+    Write-Info ".env configured."
+
+    # ── Step 5: Install services ─────────────────────────────────────────
+
+    Write-Host ""
+    $installSvc = Read-Host "==> Install background services (API server + vault indexer)? [Y/n]"
+    if (-not $installSvc -or $installSvc -match "^[Yy]") {
+        Install-ScheduledTasks -VenvPython $venvPython -IntervalMin $indexInterval
+    } else {
+        Write-Info "Skipped service installation."
+    }
+
+    # ── Step 6: Initial index ────────────────────────────────────────────
+
+    Write-Host ""
+    $runIndex = Read-Host "==> Run the vault indexer now? (recommended for first install) [Y/n]"
+    if (-not $runIndex -or $runIndex -match "^[Yy]") {
+        Write-Info "Indexing vault (this may take a minute)..."
+        & $venvPython (Join-Path $ProjectDir "src\index_vault.py")
+        Write-Info "Indexing complete."
+    }
+
+    # ── Summary ──────────────────────────────────────────────────────────
+
+    Write-Host ""
+    Write-Host "  ========================"
+    Write-Host "  Installation complete!"
+    Write-Host "  ========================"
+    Write-Host ""
+    Write-Host "  Project:     $ProjectDir"
+    Write-Host "  Python:      $pythonPath"
+    Write-Host "  Venv:        $ProjectDir\.venv\"
+    Write-Host "  Vault:       $vaultPath"
+    Write-Host "  API port:    $apiPort"
+    Write-Host "  Index every: $indexInterval min"
+    Write-Host ""
+
+    if (-not $installSvc -or $installSvc -match "^[Yy]") {
+        Write-Host "  Services (Task Scheduler):"
+        Write-Host "    View:    Get-ScheduledTask | Where-Object TaskName -like 'ObsidianTools*'"
+        Write-Host "    Start:   Start-ScheduledTask -TaskName ObsidianToolsAPI"
+        Write-Host "    Stop:    Stop-ScheduledTask -TaskName ObsidianToolsAPI"
+        Write-Host "    Remove:  .\uninstall.ps1"
+    }
+
+    Write-Host ""
+    Write-Host "  Uninstall:   .\uninstall.ps1"
+    Write-Host ""
+}
+
+Main

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,404 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ── Constants ────────────────────────────────────────────────────────────────
+
+MIN_MINOR=11
+MAX_MINOR=13
+PREFERRED_VERSION="3.12.8"
+PROJECT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+info()  { printf '\033[1;34m==> %s\033[0m\n' "$*"; }
+warn()  { printf '\033[1;33m==> %s\033[0m\n' "$*"; }
+error() { printf '\033[1;31m==> %s\033[0m\n' "$*" >&2; }
+ask()   { printf '\033[1;32m==> %s\033[0m ' "$1"; }
+
+detect_os() {
+    case "$(uname -s)" in
+        Darwin) echo "macos" ;;
+        Linux)  echo "linux" ;;
+        *)      error "Unsupported OS: $(uname -s)"; exit 1 ;;
+    esac
+}
+
+# Check if a Python binary is compatible (>=3.11, <=3.13).
+# Returns 0 if compatible, 1 otherwise.
+check_python_version() {
+    local py="$1"
+    local version
+    version="$("$py" --version 2>/dev/null | awk '{print $2}')" || return 1
+    local minor
+    minor="$(echo "$version" | cut -d. -f2)"
+    [[ "$minor" -ge "$MIN_MINOR" && "$minor" -le "$MAX_MINOR" ]]
+}
+
+# Search PATH for a compatible Python binary.
+# Prints the path if found, returns 1 otherwise.
+find_compatible_python() {
+    local candidates=(python3.12 python3.13 python3.11 python3)
+    for cmd in "${candidates[@]}"; do
+        local path
+        path="$(command -v "$cmd" 2>/dev/null)" || continue
+        if check_python_version "$path"; then
+            echo "$path"
+            return 0
+        fi
+    done
+    return 1
+}
+
+# If the Python binary is a pyenv shim, resolve the real binary path.
+resolve_real_python() {
+    local py="$1"
+    local resolved="$py"
+
+    # Detect pyenv shim
+    if [[ "$py" == *".pyenv/shims/"* ]] || [[ "$(file "$py" 2>/dev/null)" == *"script"* && -d "$HOME/.pyenv" ]]; then
+        local version
+        version="$("$py" --version 2>/dev/null | awk '{print $2}')"
+        local minor
+        minor="$(echo "$version" | cut -d. -f2)"
+
+        if command -v pyenv &>/dev/null; then
+            resolved="$(pyenv which "python3.${minor}" 2>/dev/null)" || resolved="$py"
+        fi
+    fi
+
+    # Final realpath resolution
+    if command -v realpath &>/dev/null; then
+        resolved="$(realpath "$resolved")"
+    elif command -v readlink &>/dev/null; then
+        resolved="$(readlink -f "$resolved" 2>/dev/null)" || true
+    fi
+
+    echo "$resolved"
+}
+
+# Offer to install a compatible Python via pyenv.
+offer_pyenv_install() {
+    local os="$1"
+
+    if command -v pyenv &>/dev/null; then
+        warn "No compatible Python (3.${MIN_MINOR}–3.${MAX_MINOR}) found."
+        ask "Install Python ${PREFERRED_VERSION} via pyenv? [Y/n]"
+        read -r answer
+        if [[ "${answer:-Y}" =~ ^[Yy]$ ]]; then
+            pyenv install "$PREFERRED_VERSION"
+            pyenv local "$PREFERRED_VERSION"
+            local py
+            py="$(pyenv which python3.12)"
+            echo "$py"
+            return 0
+        fi
+    elif [[ "$os" == "macos" ]]; then
+        if command -v brew &>/dev/null; then
+            warn "No compatible Python found. pyenv is recommended for managing Python versions."
+            ask "Install pyenv via Homebrew, then install Python ${PREFERRED_VERSION}? [Y/n]"
+            read -r answer
+            if [[ "${answer:-Y}" =~ ^[Yy]$ ]]; then
+                brew install pyenv
+                eval "$(pyenv init -)"
+                pyenv install "$PREFERRED_VERSION"
+                pyenv local "$PREFERRED_VERSION"
+                local py
+                py="$(pyenv which python3.12)"
+                echo "$py"
+                return 0
+            fi
+        else
+            error "No compatible Python found."
+            echo "Install pyenv (https://github.com/pyenv/pyenv) or Python 3.12 from python.org." >&2
+        fi
+    else
+        error "No compatible Python (3.${MIN_MINOR}–3.${MAX_MINOR}) found."
+        echo "Options:" >&2
+        echo "  - Install pyenv: https://github.com/pyenv/pyenv#installation" >&2
+        echo "  - Install from your distro: sudo apt install python3.12 (Debian/Ubuntu)" >&2
+        echo "                              sudo dnf install python3.12 (Fedora)" >&2
+    fi
+
+    return 1
+}
+
+# Prompt for a .env value. Usage: prompt_value "LABEL" "VAR_NAME" "default" "required"
+prompt_value() {
+    local label="$1" var="$2" default="${3:-}" required="${4:-false}"
+
+    while true; do
+        if [[ -n "$default" ]]; then
+            ask "${label} [${default}]:"
+        else
+            ask "${label}:"
+        fi
+        read -r value
+        value="${value:-$default}"
+
+        if [[ -z "$value" && "$required" == "true" ]]; then
+            warn "This value is required."
+            continue
+        fi
+        echo "$value"
+        return
+    done
+}
+
+# Prompt for VAULT_PATH with directory validation.
+prompt_vault_path() {
+    while true; do
+        ask "Path to your Obsidian vault:"
+        read -r vault_path
+        vault_path="${vault_path/#\~/$HOME}"
+
+        if [[ -z "$vault_path" ]]; then
+            warn "This value is required."
+        elif [[ ! -d "$vault_path" ]]; then
+            warn "Directory not found: ${vault_path}"
+        else
+            echo "$vault_path"
+            return
+        fi
+    done
+}
+
+# Write a key=value pair into the .env file.
+set_env_value() {
+    local key="$1" value="$2" env_file="${PROJECT_DIR}/.env"
+
+    if grep -q "^${key}=" "$env_file" 2>/dev/null; then
+        # Use different sed syntax for macOS vs Linux
+        if [[ "$(uname -s)" == "Darwin" ]]; then
+            sed -i '' "s|^${key}=.*|${key}=${value}|" "$env_file"
+        else
+            sed -i "s|^${key}=.*|${key}=${value}|" "$env_file"
+        fi
+    else
+        echo "${key}=${value}" >> "$env_file"
+    fi
+}
+
+# ── Service installation ────────────────────────────────────────────────────
+
+install_services_macos() {
+    local venv_python="$1" interval_min="$2"
+    local username
+    username="$(whoami)"
+    local interval_sec=$((interval_min * 60))
+    local launch_agents="$HOME/Library/LaunchAgents"
+
+    info "Installing launchd services..."
+    mkdir -p "$launch_agents"
+
+    for plist in com.obsidian-tools.api.plist com.obsidian-tools.indexer.plist; do
+        local src="${PROJECT_DIR}/services/launchd/${plist}"
+        local dest="${launch_agents}/${plist}"
+
+        # Unload if already loaded
+        launchctl unload "$dest" 2>/dev/null || true
+
+        sed \
+            -e "s|__VENV_PYTHON__|${venv_python}|g" \
+            -e "s|__PROJECT_DIR__|${PROJECT_DIR}|g" \
+            -e "s|__USERNAME__|${username}|g" \
+            -e "s|__INDEX_INTERVAL_SEC__|${interval_sec}|g" \
+            "$src" > "$dest"
+
+        launchctl load "$dest"
+    done
+
+    echo "  Installed: ${launch_agents}/com.obsidian-tools.api.plist"
+    echo "  Installed: ${launch_agents}/com.obsidian-tools.indexer.plist"
+}
+
+install_services_linux() {
+    local venv_python="$1" interval_min="$2"
+    local user_units="$HOME/.config/systemd/user"
+
+    info "Installing systemd user services..."
+    mkdir -p "$user_units"
+
+    # Install service units
+    for unit in obsidian-tools-api.service obsidian-tools-indexer.service; do
+        sed \
+            -e "s|__VENV_PYTHON__|${venv_python}|g" \
+            -e "s|__PROJECT_DIR__|${PROJECT_DIR}|g" \
+            "${PROJECT_DIR}/services/systemd/${unit}" > "${user_units}/${unit}"
+        echo "  Installed: ${user_units}/${unit}"
+    done
+
+    # Install timer
+    local timer="obsidian-tools-indexer-scheduler.timer"
+    sed \
+        -e "s|__INDEX_INTERVAL__|${interval_min}|g" \
+        "${PROJECT_DIR}/services/systemd/${timer}" > "${user_units}/${timer}"
+    echo "  Installed: ${user_units}/${timer}"
+
+    systemctl --user daemon-reload
+    systemctl --user enable --now obsidian-tools-api.service
+    systemctl --user enable --now obsidian-tools-indexer-scheduler.timer
+
+    echo ""
+    info "Hint: to keep services running after logout, run:"
+    echo "  sudo loginctl enable-linger $USER"
+}
+
+# ── Main ────────────────────────────────────────────────────────────────────
+
+main() {
+    echo ""
+    echo "  Obsidian Tools Installer"
+    echo "  ========================"
+    echo ""
+
+    local os
+    os="$(detect_os)"
+    info "Detected OS: ${os}"
+
+    # ── Step 1: Find Python ──────────────────────────────────────────────
+
+    info "Looking for a compatible Python (3.${MIN_MINOR}–3.${MAX_MINOR})..."
+    local python_path=""
+
+    if python_path="$(find_compatible_python)"; then
+        info "Found: ${python_path} ($("$python_path" --version))"
+    else
+        python_path="$(offer_pyenv_install "$os")" || {
+            error "Cannot continue without a compatible Python."
+            exit 1
+        }
+        info "Installed: ${python_path} ($("$python_path" --version))"
+    fi
+
+    # Resolve real binary (not pyenv shim)
+    local real_python
+    real_python="$(resolve_real_python "$python_path")"
+    if [[ "$real_python" != "$python_path" ]]; then
+        info "Resolved real binary: ${real_python}"
+    fi
+
+    # ── Step 2: Create virtual environment ───────────────────────────────
+
+    local venv_python="${PROJECT_DIR}/.venv/bin/python"
+
+    if [[ -f "$venv_python" ]]; then
+        if check_python_version "$venv_python"; then
+            info "Existing venv is compatible ($("$venv_python" --version)), keeping it."
+        else
+            warn "Existing venv uses $("$venv_python" --version 2>/dev/null || echo 'unknown version'), recreating..."
+            rm -rf "${PROJECT_DIR}/.venv"
+            "$real_python" -m venv "${PROJECT_DIR}/.venv"
+            info "Created virtual environment."
+        fi
+    else
+        "$real_python" -m venv "${PROJECT_DIR}/.venv"
+        info "Created virtual environment."
+    fi
+
+    # ── Step 3: Install dependencies ─────────────────────────────────────
+
+    info "Installing Python dependencies..."
+    "${PROJECT_DIR}/.venv/bin/pip" install --upgrade pip --quiet
+    "${PROJECT_DIR}/.venv/bin/pip" install -r "${PROJECT_DIR}/requirements.txt" --quiet
+    info "Dependencies installed."
+
+    # ── Step 4: Configure .env ───────────────────────────────────────────
+
+    if [[ ! -f "${PROJECT_DIR}/.env" ]]; then
+        cp "${PROJECT_DIR}/.env.example" "${PROJECT_DIR}/.env"
+        info "Created .env from .env.example"
+    else
+        info "Existing .env found, updating values."
+    fi
+
+    echo ""
+    info "Configure your environment:"
+    echo ""
+
+    local api_key vault_path fireworks_model chroma_path api_port index_interval
+
+    api_key="$(prompt_value "Fireworks API key" "FIREWORKS_API_KEY" "" "true")"
+    fireworks_model="$(prompt_value "Fireworks model (default: DeepSeek V3.1)" "FIREWORKS_MODEL" "accounts/fireworks/models/deepseek-v3p1")"
+    vault_path="$(prompt_vault_path)"
+    chroma_path="$(prompt_value "ChromaDB path" "CHROMA_PATH" "./.chroma_db")"
+    api_port="$(prompt_value "API server port" "API_PORT" "8000")"
+    index_interval="$(prompt_value "Index interval (minutes)" "INDEX_INTERVAL" "60")"
+
+    set_env_value "FIREWORKS_API_KEY" "$api_key"
+    set_env_value "FIREWORKS_MODEL" "$fireworks_model"
+    set_env_value "VAULT_PATH" "$vault_path"
+    set_env_value "CHROMA_PATH" "$chroma_path"
+    set_env_value "API_PORT" "$api_port"
+    set_env_value "INDEX_INTERVAL" "$index_interval"
+
+    info ".env configured."
+
+    # ── Step 5: Install services ─────────────────────────────────────────
+
+    echo ""
+    ask "Install background services (API server + vault indexer)? [Y/n]"
+    read -r install_svc
+    if [[ "${install_svc:-Y}" =~ ^[Yy]$ ]]; then
+        local resolved_venv_python
+        resolved_venv_python="$(resolve_real_python "$venv_python")"
+
+        case "$os" in
+            macos) install_services_macos "$resolved_venv_python" "$index_interval" ;;
+            linux) install_services_linux "$resolved_venv_python" "$index_interval" ;;
+        esac
+    else
+        info "Skipped service installation."
+    fi
+
+    # ── Step 6: Initial index ────────────────────────────────────────────
+
+    echo ""
+    ask "Run the vault indexer now? (recommended for first install) [Y/n]"
+    read -r run_index
+    if [[ "${run_index:-Y}" =~ ^[Yy]$ ]]; then
+        info "Indexing vault (this may take a minute)..."
+        "${PROJECT_DIR}/.venv/bin/python" "${PROJECT_DIR}/src/index_vault.py"
+        info "Indexing complete."
+    fi
+
+    # ── Summary ──────────────────────────────────────────────────────────
+
+    echo ""
+    echo "  ========================"
+    echo "  Installation complete!"
+    echo "  ========================"
+    echo ""
+    echo "  Project:     ${PROJECT_DIR}"
+    echo "  Python:      ${real_python}"
+    echo "  Venv:        ${PROJECT_DIR}/.venv/"
+    echo "  Vault:       ${vault_path}"
+    echo "  API port:    ${api_port}"
+    echo "  Index every: ${index_interval} min"
+    echo ""
+
+    if [[ "${install_svc:-Y}" =~ ^[Yy]$ ]]; then
+        case "$os" in
+            macos)
+                echo "  Services (launchd):"
+                echo "    Check:   launchctl list | grep obsidian-tools"
+                echo "    Logs:    tail -f ~/Library/Logs/obsidian-tools-api.log"
+                echo "    Stop:    launchctl unload ~/Library/LaunchAgents/com.obsidian-tools.api.plist"
+                echo "    Start:   launchctl load ~/Library/LaunchAgents/com.obsidian-tools.api.plist"
+                ;;
+            linux)
+                echo "  Services (systemd):"
+                echo "    Status:  systemctl --user status obsidian-tools-api"
+                echo "    Logs:    journalctl --user -u obsidian-tools-api -f"
+                echo "    Stop:    systemctl --user stop obsidian-tools-api"
+                echo "    Start:   systemctl --user start obsidian-tools-api"
+                echo "    Timer:   systemctl --user status obsidian-tools-indexer-scheduler.timer"
+                ;;
+        esac
+    fi
+
+    echo ""
+    echo "  Uninstall:   ./uninstall.sh"
+    echo ""
+}
+
+main "$@"

--- a/services/launchd/com.obsidian-tools.api.plist
+++ b/services/launchd/com.obsidian-tools.api.plist
@@ -6,18 +6,18 @@
     <string>com.obsidian-tools.api</string>
     <key>ProgramArguments</key>
     <array>
-        <string>/Users/YOUR_USERNAME/obsidian-tools/.venv/bin/python</string>
+        <string>__VENV_PYTHON__</string>
         <string>src/api_server.py</string>
     </array>
     <key>WorkingDirectory</key>
-    <string>/Users/YOUR_USERNAME/obsidian-tools</string>
+    <string>__PROJECT_DIR__</string>
     <key>RunAtLoad</key>
     <true/>
     <key>KeepAlive</key>
     <true/>
     <key>StandardOutPath</key>
-    <string>/Users/YOUR_USERNAME/Library/Logs/obsidian-tools-api.log</string>
+    <string>/Users/__USERNAME__/Library/Logs/obsidian-tools-api.log</string>
     <key>StandardErrorPath</key>
-    <string>/Users/YOUR_USERNAME/Library/Logs/obsidian-tools-api.log</string>
+    <string>/Users/__USERNAME__/Library/Logs/obsidian-tools-api.log</string>
 </dict>
 </plist>

--- a/services/launchd/com.obsidian-tools.indexer.plist
+++ b/services/launchd/com.obsidian-tools.indexer.plist
@@ -6,16 +6,16 @@
     <string>com.obsidian-tools.indexer</string>
     <key>ProgramArguments</key>
     <array>
-        <string>/Users/YOUR_USERNAME/obsidian-tools/.venv/bin/python</string>
+        <string>__VENV_PYTHON__</string>
         <string>src/index_vault.py</string>
     </array>
     <key>WorkingDirectory</key>
-    <string>/Users/YOUR_USERNAME/obsidian-tools</string>
+    <string>__PROJECT_DIR__</string>
     <key>StartInterval</key>
-    <integer>3600</integer>
+    <integer>__INDEX_INTERVAL_SEC__</integer>
     <key>StandardOutPath</key>
-    <string>/Users/YOUR_USERNAME/Library/Logs/obsidian-tools-indexer.log</string>
+    <string>/Users/__USERNAME__/Library/Logs/obsidian-tools-indexer.log</string>
     <key>StandardErrorPath</key>
-    <string>/Users/YOUR_USERNAME/Library/Logs/obsidian-tools-indexer.log</string>
+    <string>/Users/__USERNAME__/Library/Logs/obsidian-tools-indexer.log</string>
 </dict>
 </plist>

--- a/services/systemd/obsidian-tools-api.service
+++ b/services/systemd/obsidian-tools-api.service
@@ -4,8 +4,8 @@ After=network.target
 
 [Service]
 Type=simple
-WorkingDirectory=%h/obsidian-tools
-ExecStart=%h/obsidian-tools/.venv/bin/python src/api_server.py
+WorkingDirectory=__PROJECT_DIR__
+ExecStart=__VENV_PYTHON__ src/api_server.py
 Restart=on-failure
 RestartSec=5
 

--- a/services/systemd/obsidian-tools-indexer-scheduler.timer
+++ b/services/systemd/obsidian-tools-indexer-scheduler.timer
@@ -1,8 +1,9 @@
 [Unit]
-Description=Run Obsidian Tools Vault Indexer hourly
+Description=Run Obsidian Tools Vault Indexer periodically
 
 [Timer]
-OnCalendar=hourly
+OnBootSec=5min
+OnUnitActiveSec=__INDEX_INTERVAL__min
 Persistent=true
 
 [Install]

--- a/services/systemd/obsidian-tools-indexer.service
+++ b/services/systemd/obsidian-tools-indexer.service
@@ -3,5 +3,5 @@ Description=Obsidian Tools Vault Indexer
 
 [Service]
 Type=oneshot
-WorkingDirectory=%h/obsidian-tools
-ExecStart=%h/obsidian-tools/.venv/bin/python src/index_vault.py
+WorkingDirectory=__PROJECT_DIR__
+ExecStart=__VENV_PYTHON__ src/index_vault.py

--- a/services/taskscheduler/obsidian-tools-api.xml
+++ b/services/taskscheduler/obsidian-tools-api.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-16"?>
+<Task version="1.2" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
+  <RegistrationInfo>
+    <Description>Obsidian Tools API Server</Description>
+  </RegistrationInfo>
+  <Triggers>
+    <LogonTrigger>
+      <Enabled>true</Enabled>
+    </LogonTrigger>
+  </Triggers>
+  <Principals>
+    <Principal id="Author">
+      <LogonType>InteractiveToken</LogonType>
+      <RunLevel>LeastPrivilege</RunLevel>
+    </Principal>
+  </Principals>
+  <Settings>
+    <MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy>
+    <DisallowStartIfOnBatteries>false</DisallowStartIfOnBatteries>
+    <StopIfGoingOnBatteries>false</StopIfGoingOnBatteries>
+    <AllowHardTerminate>true</AllowHardTerminate>
+    <StartWhenAvailable>true</StartWhenAvailable>
+    <RunOnlyIfNetworkAvailable>false</RunOnlyIfNetworkAvailable>
+    <AllowStartOnDemand>true</AllowStartOnDemand>
+    <Enabled>true</Enabled>
+    <Hidden>false</Hidden>
+    <RunOnlyIfIdle>false</RunOnlyIfIdle>
+    <RestartOnFailure>
+      <Interval>PT5M</Interval>
+      <Count>3</Count>
+    </RestartOnFailure>
+    <ExecutionTimeLimit>PT0S</ExecutionTimeLimit>
+  </Settings>
+  <Actions Context="Author">
+    <Exec>
+      <Command>__VENV_PYTHON__</Command>
+      <Arguments>src\api_server.py</Arguments>
+      <WorkingDirectory>__PROJECT_DIR__</WorkingDirectory>
+    </Exec>
+  </Actions>
+</Task>

--- a/services/taskscheduler/obsidian-tools-indexer.xml
+++ b/services/taskscheduler/obsidian-tools-indexer.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-16"?>
+<Task version="1.2" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
+  <RegistrationInfo>
+    <Description>Obsidian Tools Vault Indexer</Description>
+  </RegistrationInfo>
+  <Triggers>
+    <LogonTrigger>
+      <Enabled>true</Enabled>
+      <Repetition>
+        <Interval>PT__INDEX_INTERVAL__M</Interval>
+        <StopAtDurationEnd>false</StopAtDurationEnd>
+      </Repetition>
+    </LogonTrigger>
+  </Triggers>
+  <Principals>
+    <Principal id="Author">
+      <LogonType>InteractiveToken</LogonType>
+      <RunLevel>LeastPrivilege</RunLevel>
+    </Principal>
+  </Principals>
+  <Settings>
+    <MultipleInstancesPolicy>Queue</MultipleInstancesPolicy>
+    <DisallowStartIfOnBatteries>false</DisallowStartIfOnBatteries>
+    <StopIfGoingOnBatteries>false</StopIfGoingOnBatteries>
+    <AllowHardTerminate>true</AllowHardTerminate>
+    <StartWhenAvailable>true</StartWhenAvailable>
+    <RunOnlyIfNetworkAvailable>false</RunOnlyIfNetworkAvailable>
+    <AllowStartOnDemand>true</AllowStartOnDemand>
+    <Enabled>true</Enabled>
+    <Hidden>false</Hidden>
+    <RunOnlyIfIdle>false</RunOnlyIfIdle>
+    <ExecutionTimeLimit>PT1H</ExecutionTimeLimit>
+  </Settings>
+  <Actions Context="Author">
+    <Exec>
+      <Command>__VENV_PYTHON__</Command>
+      <Arguments>src\index_vault.py</Arguments>
+      <WorkingDirectory>__PROJECT_DIR__</WorkingDirectory>
+    </Exec>
+  </Actions>
+</Task>

--- a/src/api_server.py
+++ b/src/api_server.py
@@ -11,6 +11,7 @@ from mcp import ClientSession, StdioServerParameters
 from mcp.client.stdio import stdio_client
 from pydantic import BaseModel
 
+from config import API_PORT
 from qwen_agent import (
     PROJECT_ROOT,
     SYSTEM_PROMPT,
@@ -136,7 +137,7 @@ def main():
     uvicorn.run(
         "api_server:app",
         host="127.0.0.1",
-        port=8000,
+        port=API_PORT,
         reload=False,
     )
 

--- a/src/config.py
+++ b/src/config.py
@@ -27,6 +27,16 @@ PREFERENCES_FILE = VAULT_PATH / "Preferences.md"
 ATTACHMENTS_DIR = VAULT_PATH / "Attachments"
 
 # Model configuration
-LLM_MODEL = os.getenv("LLM_MODEL", "accounts/fireworks/models/deepseek-v3p1")
+FIREWORKS_MODEL = os.getenv(
+    "FIREWORKS_MODEL",
+    os.getenv("LLM_MODEL", "accounts/fireworks/models/deepseek-v3p1"),
+)
+LLM_MODEL = FIREWORKS_MODEL  # backward compat alias
 EMBEDDING_MODEL = os.getenv("EMBEDDING_MODEL", "all-MiniLM-L6-v2")
 WHISPER_MODEL = os.getenv("WHISPER_MODEL", "whisper-v3")
+
+# Server configuration
+API_PORT = int(os.getenv("API_PORT", "8000"))
+
+# Indexer configuration
+INDEX_INTERVAL = int(os.getenv("INDEX_INTERVAL", "60"))

--- a/uninstall.ps1
+++ b/uninstall.ps1
@@ -1,0 +1,78 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Uninstalls obsidian-tools services and optionally the virtual environment.
+.DESCRIPTION
+    Run from the project root: .\uninstall.ps1
+#>
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$ProjectDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
+
+function Write-Info { param($msg) Write-Host "==> $msg" -ForegroundColor Cyan }
+function Write-Warn { param($msg) Write-Host "==> $msg" -ForegroundColor Yellow }
+
+function Remove-ObsidianTasks {
+    Write-Info "Removing Task Scheduler tasks..."
+    $removed = 0
+
+    foreach ($name in @("ObsidianToolsAPI", "ObsidianToolsIndexer")) {
+        try {
+            $task = Get-ScheduledTask -TaskName $name -ErrorAction Stop
+            Stop-ScheduledTask -TaskName $name -ErrorAction SilentlyContinue
+            Unregister-ScheduledTask -TaskName $name -Confirm:$false
+            Write-Host "  Removed: $name"
+            $removed++
+        } catch {
+            # Task doesn't exist, skip
+        }
+    }
+
+    if ($removed -eq 0) {
+        Write-Info "No scheduled tasks found."
+    } else {
+        Write-Info "Removed $removed scheduled task(s)."
+    }
+}
+
+function Main {
+    Write-Host ""
+    Write-Host "  Obsidian Tools Uninstaller"
+    Write-Host "  =========================="
+    Write-Host ""
+
+    # ── Remove services ──────────────────────────────────────────────────
+
+    Remove-ObsidianTasks
+
+    # ── Remove venv ──────────────────────────────────────────────────────
+
+    $venvDir = Join-Path $ProjectDir ".venv"
+    if (Test-Path $venvDir) {
+        Write-Host ""
+        $answer = Read-Host "==> Remove virtual environment (.venv)? [y/N]"
+        if ($answer -match "^[Yy]") {
+            Remove-Item $venvDir -Recurse -Force
+            Write-Info "Removed .venv\"
+        } else {
+            Write-Info "Kept .venv\"
+        }
+    }
+
+    # ── Summary ──────────────────────────────────────────────────────────
+
+    Write-Host ""
+    Write-Info "Uninstall complete."
+    Write-Host ""
+    Write-Host "  Preserved:"
+    Write-Host "    .env          (your configuration)"
+    Write-Host "    .chroma_db\   (your search index)"
+    Write-Host ""
+    Write-Host "  To remove everything, delete the project directory:"
+    Write-Host "    Remove-Item -Recurse -Force $ProjectDir"
+    Write-Host ""
+}
+
+Main

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROJECT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+info()  { printf '\033[1;34m==> %s\033[0m\n' "$*"; }
+warn()  { printf '\033[1;33m==> %s\033[0m\n' "$*"; }
+ask()   { printf '\033[1;32m==> %s\033[0m ' "$1"; }
+
+detect_os() {
+    case "$(uname -s)" in
+        Darwin) echo "macos" ;;
+        Linux)  echo "linux" ;;
+        *)      echo "unknown" ;;
+    esac
+}
+
+uninstall_services_macos() {
+    local launch_agents="$HOME/Library/LaunchAgents"
+    local removed=0
+
+    for plist in com.obsidian-tools.api.plist com.obsidian-tools.indexer.plist; do
+        local path="${launch_agents}/${plist}"
+        if [[ -f "$path" ]]; then
+            launchctl unload "$path" 2>/dev/null || true
+            rm -f "$path"
+            echo "  Removed: ${path}"
+            removed=$((removed + 1))
+        fi
+    done
+
+    if [[ "$removed" -eq 0 ]]; then
+        info "No launchd services found."
+    else
+        info "Removed ${removed} launchd service(s)."
+    fi
+}
+
+uninstall_services_linux() {
+    local user_units="$HOME/.config/systemd/user"
+    local removed=0
+
+    # Stop and disable
+    for unit in obsidian-tools-api.service obsidian-tools-indexer-scheduler.timer; do
+        if systemctl --user is-active "$unit" &>/dev/null; then
+            systemctl --user stop "$unit" 2>/dev/null || true
+        fi
+        if systemctl --user is-enabled "$unit" &>/dev/null; then
+            systemctl --user disable "$unit" 2>/dev/null || true
+        fi
+    done
+
+    # Remove unit files
+    for file in obsidian-tools-api.service obsidian-tools-indexer.service obsidian-tools-indexer-scheduler.timer; do
+        local path="${user_units}/${file}"
+        if [[ -f "$path" ]]; then
+            rm -f "$path"
+            echo "  Removed: ${path}"
+            removed=$((removed + 1))
+        fi
+    done
+
+    if [[ "$removed" -gt 0 ]]; then
+        systemctl --user daemon-reload
+        info "Removed ${removed} systemd unit(s)."
+    else
+        info "No systemd units found."
+    fi
+}
+
+main() {
+    echo ""
+    echo "  Obsidian Tools Uninstaller"
+    echo "  =========================="
+    echo ""
+
+    local os
+    os="$(detect_os)"
+
+    # ── Remove services ──────────────────────────────────────────────────
+
+    info "Removing background services..."
+    case "$os" in
+        macos) uninstall_services_macos ;;
+        linux) uninstall_services_linux ;;
+        *)     warn "Unknown OS, skipping service removal." ;;
+    esac
+
+    # ── Remove venv ──────────────────────────────────────────────────────
+
+    if [[ -d "${PROJECT_DIR}/.venv" ]]; then
+        echo ""
+        ask "Remove virtual environment (.venv)? [y/N]"
+        read -r answer
+        if [[ "${answer:-N}" =~ ^[Yy]$ ]]; then
+            rm -rf "${PROJECT_DIR}/.venv"
+            info "Removed .venv/"
+        else
+            info "Kept .venv/"
+        fi
+    fi
+
+    # ── Summary ──────────────────────────────────────────────────────────
+
+    echo ""
+    info "Uninstall complete."
+    echo ""
+    echo "  Preserved:"
+    echo "    .env          (your configuration)"
+    echo "    .chroma_db/   (your search index)"
+    echo ""
+    echo "  To remove everything, delete the project directory:"
+    echo "    rm -rf ${PROJECT_DIR}"
+    echo ""
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

- Adds `install.sh` (macOS/Linux) and `install.ps1` (Windows) that handle Python version detection, venv creation from the real binary (not pyenv shims), dependency installation, interactive `.env` configuration, and background service setup
- Adds companion `uninstall.sh` and `uninstall.ps1` that reverse service installation
- Standardizes all service templates to `__PLACEHOLDER__` style for reliable sed substitution
- Adds Windows Task Scheduler XML templates (`services/taskscheduler/`)
- Introduces `FIREWORKS_MODEL`, `API_PORT`, and `INDEX_INTERVAL` env vars in `.env.example` and `config.py`
- Updates `api_server.py` to read `API_PORT` from config
- Updates README with quick-install path alongside preserved manual instructions

## Test plan

- [ ] Run `./install.sh` on Linux — verify Python detection, venv creation, `.env` prompts, systemd service installation
- [ ] Run `./install.sh` on macOS — verify pyenv resolution, launchd plist installation
- [ ] Run `.\install.ps1` on Windows — verify py launcher detection, Task Scheduler registration
- [ ] Run `./uninstall.sh` / `.\uninstall.ps1` — verify services are removed, `.env` and `.chroma_db/` are preserved
- [ ] Verify existing tests still pass (`pytest tests/ -v`)
- [ ] Verify `FIREWORKS_MODEL` falls back to `LLM_MODEL` env var for backward compat

🤖 Generated with [Claude Code](https://claude.com/claude-code)