### PR TITLE
feat: tool-specific compaction stubs

### DIFF
--- a/src/services/compaction.py
+++ b/src/services/compaction.py
@@ -1,32 +1,29 @@
 """Tool message compaction for managing conversation token usage."""
 
 import json
+from typing import Callable
+
+SNIPPET_LENGTH = 80
+CONTENT_PREVIEW_LENGTH = 100
 
 
-def build_tool_stub(content: str) -> str:
-    """Build a compact stub from a tool result string.
-
-    Parses JSON tool results and extracts key metadata (status, file paths,
-    result count, errors). Non-JSON content is summarized to 200 chars.
-    """
-    try:
-        data = json.loads(content)
-    except (json.JSONDecodeError, TypeError):
-        summary = content[:200] if len(content) > 200 else content
-        return json.dumps({"status": "unknown", "summary": summary})
-
+def _base_stub(data: dict) -> dict:
+    """Extract common fields shared by all stubs."""
     stub: dict = {}
-
     if "success" in data:
         stub["status"] = "success" if data["success"] else "error"
     else:
         stub["status"] = "unknown"
-
     if "error" in data:
         stub["error"] = data["error"]
-
     if "message" in data:
         stub["message"] = data["message"]
+    return stub
+
+
+def _build_generic_stub(data: dict) -> str:
+    """Generic stub builder for tools without specific handlers."""
+    stub = _base_stub(data)
 
     if "path" in data:
         stub["path"] = data["path"]
@@ -51,13 +48,113 @@ def build_tool_stub(content: str) -> str:
     return json.dumps(stub)
 
 
+def _build_search_vault_stub(data: dict) -> str:
+    """Compact search_vault: keep source, heading, and content snippet per result."""
+    stub = _base_stub(data)
+    if "results" in data and isinstance(data["results"], list):
+        stub["result_count"] = len(data["results"])
+        stub["results"] = [
+            {
+                "source": r["source"],
+                "heading": r.get("heading", ""),
+                "snippet": r.get("content", "")[:SNIPPET_LENGTH],
+            }
+            for r in data["results"]
+            if isinstance(r, dict) and "source" in r
+        ]
+    return json.dumps(stub)
+
+
+def _build_read_file_stub(data: dict) -> str:
+    """Compact read_file: keep content preview and pagination markers."""
+    stub = _base_stub(data)
+    if "content" in data:
+        content = data["content"]
+        stub["content_length"] = len(content)
+        stub["content_preview"] = content[:CONTENT_PREVIEW_LENGTH]
+        trunc_marker = "[... truncated at char"
+        if trunc_marker in content:
+            idx = content.rfind(trunc_marker)
+            if idx != -1:
+                stub["truncation_marker"] = content[idx:]
+    if "path" in data:
+        stub["path"] = data["path"]
+    return json.dumps(stub)
+
+
+def _build_list_stub(data: dict) -> str:
+    """Compact list tools: preserve full results list (already compact) and total."""
+    stub = _base_stub(data)
+    if "results" in data and isinstance(data["results"], list):
+        stub["result_count"] = len(data["results"])
+        stub["results"] = data["results"]
+    if "total" in data:
+        stub["total"] = data["total"]
+    return json.dumps(stub)
+
+
+def _build_web_search_stub(data: dict) -> str:
+    """Compact web_search: keep title and URL, drop snippets."""
+    stub = _base_stub(data)
+    if "results" in data and isinstance(data["results"], list):
+        stub["result_count"] = len(data["results"])
+        stub["results"] = [
+            {"title": r.get("title", ""), "url": r.get("url", "")}
+            for r in data["results"]
+            if isinstance(r, dict)
+        ]
+    return json.dumps(stub)
+
+
+_TOOL_STUB_BUILDERS: dict[str, Callable[[dict], str]] = {
+    "search_vault": _build_search_vault_stub,
+    "read_file": _build_read_file_stub,
+    "web_search": _build_web_search_stub,
+    "find_backlinks": _build_list_stub,
+    "find_outlinks": _build_list_stub,
+    "search_by_folder": _build_list_stub,
+    "list_files_by_frontmatter": _build_list_stub,
+    "search_by_date_range": _build_list_stub,
+}
+
+
+def build_tool_stub(content: str, tool_name: str | None = None) -> str:
+    """Build a compact stub from a tool result string.
+
+    Dispatches to tool-specific extractors when tool_name is known,
+    falling back to generic extraction otherwise.
+    """
+    try:
+        data = json.loads(content)
+    except (json.JSONDecodeError, TypeError):
+        summary = content[:200] if len(content) > 200 else content
+        return json.dumps({"status": "unknown", "summary": summary})
+
+    if tool_name and tool_name in _TOOL_STUB_BUILDERS:
+        return _TOOL_STUB_BUILDERS[tool_name](data)
+
+    return _build_generic_stub(data)
+
+
 def compact_tool_messages(messages: list[dict]) -> None:
     """Replace tool results with compact stubs in-place."""
+    # Build tool_call_id -> tool_name mapping from assistant messages
+    tool_name_map: dict[str, str] = {}
+    for msg in messages:
+        if msg.get("role") == "assistant" and msg.get("tool_calls"):
+            for tc in msg["tool_calls"]:
+                call_id = tc.get("id")
+                name = tc.get("function", {}).get("name")
+                if call_id and name:
+                    tool_name_map[call_id] = name
+
     for i, msg in enumerate(messages):
         if msg.get("role") == "tool" and not msg.get("_compacted"):
+            call_id = msg["tool_call_id"]
+            tool_name = tool_name_map.get(call_id)
             messages[i] = {
                 "role": "tool",
-                "tool_call_id": msg["tool_call_id"],
-                "content": build_tool_stub(msg["content"]),
+                "tool_call_id": call_id,
+                "content": build_tool_stub(msg["content"], tool_name),
                 "_compacted": True,
             }

--- a/tests/test_session_management.py
+++ b/tests/test_session_management.py
@@ -77,6 +77,137 @@ class TestBuildToolStub:
         assert parsed["summary"] == content
 
 
+    # --- Tool-specific stub tests ---
+
+    def test_search_vault_stub_preserves_headings_and_snippets(self):
+        """search_vault stub keeps source, heading, and content snippet."""
+        content = json.dumps({
+            "success": True,
+            "results": [
+                {"source": "Notes/meeting.md", "content": "Discussed the quarterly review and budget allocations for Q3", "heading": "## Meeting Notes"},
+                {"source": "Notes/project.md", "content": "Project timeline updated", "heading": "### Timeline"},
+            ],
+        })
+        stub = build_tool_stub(content, "search_vault")
+        parsed = json.loads(stub)
+        assert parsed["status"] == "success"
+        assert parsed["result_count"] == 2
+        assert len(parsed["results"]) == 2
+        assert parsed["results"][0]["source"] == "Notes/meeting.md"
+        assert parsed["results"][0]["heading"] == "## Meeting Notes"
+        assert parsed["results"][0]["snippet"].startswith("Discussed")
+
+    def test_search_vault_stub_truncates_long_content(self):
+        """search_vault snippet is capped at SNIPPET_LENGTH chars."""
+        content = json.dumps({
+            "success": True,
+            "results": [{"source": "a.md", "content": "x" * 200, "heading": ""}],
+        })
+        stub = build_tool_stub(content, "search_vault")
+        parsed = json.loads(stub)
+        assert len(parsed["results"][0]["snippet"]) == 80
+
+    def test_search_vault_stub_empty_results(self):
+        """search_vault with no results preserves message."""
+        content = json.dumps({
+            "success": True,
+            "message": "No matching documents found",
+            "results": [],
+        })
+        stub = build_tool_stub(content, "search_vault")
+        parsed = json.loads(stub)
+        assert parsed["result_count"] == 0
+        assert parsed["message"] == "No matching documents found"
+
+    def test_read_file_stub_preserves_preview(self):
+        """read_file stub keeps first 100 chars as preview."""
+        file_content = "# My Note\n\nThis is the beginning of a very long file with lots of content that goes on and on and on..."
+        content = json.dumps({"success": True, "content": file_content})
+        stub = build_tool_stub(content, "read_file")
+        parsed = json.loads(stub)
+        assert parsed["status"] == "success"
+        assert parsed["content_length"] == len(file_content)
+        assert parsed["content_preview"] == file_content[:100]
+
+    def test_read_file_stub_preserves_truncation_marker(self):
+        """read_file stub preserves pagination truncation markers."""
+        file_content = "Some content here...\n\n[... truncated at char 4000 of 12000. Use offset=4000 to read more.]"
+        content = json.dumps({"success": True, "content": file_content})
+        stub = build_tool_stub(content, "read_file")
+        parsed = json.loads(stub)
+        assert "truncation_marker" in parsed
+        assert "offset=4000" in parsed["truncation_marker"]
+
+    def test_read_file_stub_no_truncation(self):
+        """read_file stub without truncation omits truncation_marker."""
+        content = json.dumps({"success": True, "content": "Short file"})
+        stub = build_tool_stub(content, "read_file")
+        parsed = json.loads(stub)
+        assert "truncation_marker" not in parsed
+        assert parsed["content_preview"] == "Short file"
+
+    def test_list_stub_preserves_total(self):
+        """List tool stubs preserve total for pagination context."""
+        content = json.dumps({
+            "success": True,
+            "results": ["file1.md", "file2.md", "file3.md"],
+            "total": 25,
+        })
+        for tool in ["find_backlinks", "find_outlinks", "search_by_folder",
+                      "list_files_by_frontmatter", "search_by_date_range"]:
+            stub = build_tool_stub(content, tool)
+            parsed = json.loads(stub)
+            assert parsed["total"] == 25, f"Failed for {tool}"
+            assert parsed["result_count"] == 3
+            assert parsed["results"] == ["file1.md", "file2.md", "file3.md"]
+
+    def test_list_stub_empty_results(self):
+        """List tool stub with empty results preserves total=0."""
+        content = json.dumps({
+            "success": True,
+            "message": "No backlinks found",
+            "results": [],
+            "total": 0,
+        })
+        stub = build_tool_stub(content, "find_backlinks")
+        parsed = json.loads(stub)
+        assert parsed["total"] == 0
+        assert parsed["result_count"] == 0
+
+    def test_web_search_stub_keeps_title_url(self):
+        """web_search stub keeps title and URL but drops snippet."""
+        content = json.dumps({
+            "success": True,
+            "results": [
+                {"title": "Example Page", "url": "https://example.com", "snippet": "A very long snippet..."},
+            ],
+        })
+        stub = build_tool_stub(content, "web_search")
+        parsed = json.loads(stub)
+        assert parsed["results"][0]["title"] == "Example Page"
+        assert parsed["results"][0]["url"] == "https://example.com"
+        assert "snippet" not in parsed["results"][0]
+
+    def test_unknown_tool_falls_back_to_generic(self):
+        """Unknown tool name uses generic stub builder."""
+        content = json.dumps({"success": True, "path": "new/note.md"})
+        stub = build_tool_stub(content, "create_file")
+        parsed = json.loads(stub)
+        assert parsed["status"] == "success"
+        assert parsed["path"] == "new/note.md"
+
+    def test_none_tool_name_uses_generic(self):
+        """None tool_name uses generic stub builder (backward compat)."""
+        content = json.dumps({
+            "success": True,
+            "results": [{"source": "a.md", "content": "..."}],
+        })
+        stub = build_tool_stub(content)
+        parsed = json.loads(stub)
+        assert "files" in parsed
+        assert "results" not in parsed
+
+
 class TestCompactToolMessages:
     """Tests for compact_tool_messages."""
 
@@ -119,6 +250,58 @@ class TestCompactToolMessages:
         original = [m.copy() for m in messages]
         compact_tool_messages(messages)
         assert messages == original
+
+    def test_resolves_tool_name_from_assistant_messages(self):
+        """compact_tool_messages uses tool name for tool-specific stubs."""
+        messages = [
+            {"role": "assistant", "content": None, "tool_calls": [
+                {"id": "call_1", "function": {"name": "search_vault"}, "type": "function"},
+            ]},
+            {"role": "tool", "tool_call_id": "call_1",
+             "content": json.dumps({
+                 "success": True,
+                 "results": [{"source": "note.md", "content": "long text here", "heading": "## Intro"}],
+             })},
+        ]
+        compact_tool_messages(messages)
+        parsed = json.loads(messages[1]["content"])
+        # search_vault stub has "results" list with heading/snippet, not generic "files"
+        assert "results" in parsed
+        assert parsed["results"][0]["heading"] == "## Intro"
+        assert "snippet" in parsed["results"][0]
+
+    def test_missing_tool_name_uses_generic(self):
+        """Tool message without matching assistant message uses generic stub."""
+        messages = [
+            {"role": "tool", "tool_call_id": "orphan_call",
+             "content": json.dumps({"success": True, "path": "test.md"})},
+        ]
+        compact_tool_messages(messages)
+        parsed = json.loads(messages[0]["content"])
+        assert parsed["path"] == "test.md"
+
+    def test_multiple_tool_calls_resolved_correctly(self):
+        """Multiple tool calls in one assistant message are all resolved."""
+        messages = [
+            {"role": "assistant", "content": None, "tool_calls": [
+                {"id": "call_1", "function": {"name": "search_vault"}, "type": "function"},
+                {"id": "call_2", "function": {"name": "read_file"}, "type": "function"},
+            ]},
+            {"role": "tool", "tool_call_id": "call_1",
+             "content": json.dumps({
+                 "success": True,
+                 "results": [{"source": "a.md", "content": "text", "heading": "## H"}],
+             })},
+            {"role": "tool", "tool_call_id": "call_2",
+             "content": json.dumps({"success": True, "content": "File content here"})},
+        ]
+        compact_tool_messages(messages)
+
+        search_stub = json.loads(messages[1]["content"])
+        assert "results" in search_stub
+
+        read_stub = json.loads(messages[2]["content"])
+        assert "content_preview" in read_stub
 
 
 from api_server import Session, get_or_create_session, file_sessions


### PR DESCRIPTION
## Summary

- Add tool-specific stub builders for `search_vault`, `read_file`, `web_search`, and all list tools (backlinks, outlinks, folder, frontmatter, date_range)
- `compact_tool_messages` now resolves tool names from assistant messages and dispatches to specialized extractors
- Unknown tools fall back to existing generic logic (fully backward compatible)

**What's preserved now vs before:**

| Tool | Before | After |
|------|--------|-------|
| `search_vault` | file list + count | source + heading + 80-char snippet per result |
| `read_file` | `has_content: true, content_length: N` | 100-char content preview + truncation marker |
| List tools | count only | full results list + `total` for pagination |
| `web_search` | generic | title + URL per result |

## Test plan

- [x] 15 new tests covering all tool-specific stubs, fallback behavior, and tool name resolution
- [x] All 6 existing compaction tests pass unchanged (backward compat)
- [x] Full suite: 230 tests passing

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)