### PR TITLE
Add test coverage for utility.py and config.py

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,188 @@
+"""Tests for src/config.py.
+
+config.py executes module-level code at import time, so env vars must be set
+BEFORE the module is (re-)imported. We use importlib.reload(config) with
+monkeypatch to control env vars and re-evaluate module-level assignments.
+"""
+
+import importlib
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def reload_config():
+    """Reload config after each test to restore module state."""
+    import src.config as config
+    yield config
+    importlib.reload(config)
+
+
+def _reload(monkeypatch) -> object:
+    """Reload config with load_dotenv disabled so .env doesn't override monkeypatched env."""
+    import src.config as config
+    with patch("dotenv.load_dotenv"):
+        importlib.reload(config)
+    return config
+
+
+# ---------------------------------------------------------------------------
+# VAULT_PATH
+# ---------------------------------------------------------------------------
+
+
+def test_vault_path_default(monkeypatch):
+    monkeypatch.delenv("VAULT_PATH", raising=False)
+    config = _reload(monkeypatch)
+    expected = Path("~/Documents/obsidian-vault").expanduser()
+    assert config.VAULT_PATH == expected
+
+
+def test_vault_path_custom(monkeypatch, tmp_path):
+    monkeypatch.setenv("VAULT_PATH", str(tmp_path))
+    config = _reload(monkeypatch)
+    assert config.VAULT_PATH == tmp_path
+
+
+# ---------------------------------------------------------------------------
+# CHROMA_PATH
+# ---------------------------------------------------------------------------
+
+
+def test_chroma_path_relative(monkeypatch):
+    monkeypatch.delenv("CHROMA_PATH", raising=False)
+    config = _reload(monkeypatch)
+    # Project root is the parent of src/ which is the parent of config.py
+    import src.config as cfg_module
+    project_root = Path(cfg_module.__file__).parent.parent
+    expected = str(project_root / "./.chroma_db")
+    assert config.CHROMA_PATH == expected
+
+
+def test_chroma_path_absolute(monkeypatch, tmp_path):
+    abs_path = str(tmp_path / "chroma")
+    monkeypatch.setenv("CHROMA_PATH", abs_path)
+    config = _reload(monkeypatch)
+    assert config.CHROMA_PATH == abs_path
+
+
+# ---------------------------------------------------------------------------
+# EXCLUDED_DIRS
+# ---------------------------------------------------------------------------
+
+
+def test_excluded_dirs_contents(monkeypatch):
+    config = _reload(monkeypatch)
+    assert config.EXCLUDED_DIRS == {'.venv', '.chroma_db', '.trash', '.obsidian', '.git'}
+
+
+# ---------------------------------------------------------------------------
+# PREFERENCES_FILE and ATTACHMENTS_DIR
+# ---------------------------------------------------------------------------
+
+
+def test_preferences_file_under_vault(monkeypatch, tmp_path):
+    monkeypatch.setenv("VAULT_PATH", str(tmp_path))
+    config = _reload(monkeypatch)
+    assert config.PREFERENCES_FILE == tmp_path / "Preferences.md"
+
+
+def test_attachments_dir_under_vault(monkeypatch, tmp_path):
+    monkeypatch.setenv("VAULT_PATH", str(tmp_path))
+    config = _reload(monkeypatch)
+    assert config.ATTACHMENTS_DIR == tmp_path / "Attachments"
+
+
+# ---------------------------------------------------------------------------
+# API_PORT
+# ---------------------------------------------------------------------------
+
+
+def test_api_port_default(monkeypatch):
+    monkeypatch.delenv("API_PORT", raising=False)
+    config = _reload(monkeypatch)
+    assert config.API_PORT == 8000
+
+
+def test_api_port_custom(monkeypatch):
+    monkeypatch.setenv("API_PORT", "9090")
+    config = _reload(monkeypatch)
+    assert config.API_PORT == 9090
+
+
+# ---------------------------------------------------------------------------
+# MAX_SESSIONS
+# ---------------------------------------------------------------------------
+
+
+def test_max_sessions_default(monkeypatch):
+    monkeypatch.delenv("MAX_SESSIONS", raising=False)
+    config = _reload(monkeypatch)
+    assert config.MAX_SESSIONS == 20
+
+
+def test_max_sessions_clamped(monkeypatch):
+    monkeypatch.setenv("MAX_SESSIONS", "0")
+    config = _reload(monkeypatch)
+    assert config.MAX_SESSIONS == 1
+
+
+# ---------------------------------------------------------------------------
+# MAX_SESSION_MESSAGES
+# ---------------------------------------------------------------------------
+
+
+def test_max_session_messages_default(monkeypatch):
+    monkeypatch.delenv("MAX_SESSION_MESSAGES", raising=False)
+    config = _reload(monkeypatch)
+    assert config.MAX_SESSION_MESSAGES == 50
+
+
+def test_max_session_messages_clamped(monkeypatch):
+    monkeypatch.setenv("MAX_SESSION_MESSAGES", "1")
+    config = _reload(monkeypatch)
+    assert config.MAX_SESSION_MESSAGES == 2
+
+
+# ---------------------------------------------------------------------------
+# Model configuration
+# ---------------------------------------------------------------------------
+
+
+def test_fireworks_model_default(monkeypatch):
+    monkeypatch.delenv("FIREWORKS_MODEL", raising=False)
+    monkeypatch.delenv("LLM_MODEL", raising=False)
+    config = _reload(monkeypatch)
+    assert config.FIREWORKS_MODEL == "accounts/fireworks/models/gpt-oss-120b"
+
+
+def test_fireworks_model_env(monkeypatch):
+    monkeypatch.setenv("FIREWORKS_MODEL", "accounts/fireworks/models/custom-model")
+    config = _reload(monkeypatch)
+    assert config.FIREWORKS_MODEL == "accounts/fireworks/models/custom-model"
+
+
+def test_fireworks_model_llm_fallback(monkeypatch):
+    monkeypatch.delenv("FIREWORKS_MODEL", raising=False)
+    monkeypatch.setenv("LLM_MODEL", "accounts/fireworks/models/fallback-model")
+    config = _reload(monkeypatch)
+    assert config.FIREWORKS_MODEL == "accounts/fireworks/models/fallback-model"
+
+
+def test_llm_model_alias(monkeypatch):
+    monkeypatch.setenv("FIREWORKS_MODEL", "accounts/fireworks/models/some-model")
+    config = _reload(monkeypatch)
+    assert config.LLM_MODEL == config.FIREWORKS_MODEL
+
+
+# ---------------------------------------------------------------------------
+# INDEX_INTERVAL
+# ---------------------------------------------------------------------------
+
+
+def test_index_interval_default(monkeypatch):
+    monkeypatch.delenv("INDEX_INTERVAL", raising=False)
+    config = _reload(monkeypatch)
+    assert config.INDEX_INTERVAL == 60

--- a/tests/test_tools_utility.py
+++ b/tests/test_tools_utility.py
@@ -1,0 +1,157 @@
+"""Tests for tools/utility.py - utility tools (logging, date)."""
+
+import json
+import re
+from datetime import datetime
+from unittest.mock import patch
+
+import pytest
+
+from tools.utility import get_current_date, log_interaction
+
+
+class TestGetCurrentDate:
+    """Tests for get_current_date tool."""
+
+    def test_get_current_date_format(self):
+        """Should return success with date in YYYY-MM-DD format."""
+        result = json.loads(get_current_date())
+        assert result["success"] is True
+        assert "date" in result
+        # Validate format with regex: YYYY-MM-DD
+        assert re.match(r"^\d{4}-\d{2}-\d{2}$", result["date"])
+
+    def test_get_current_date_matches_today(self):
+        """Should return exact current date when mocked."""
+        mock_date = datetime(2025, 6, 15, 14, 30, 0)
+        with patch("tools.utility.datetime") as mock_datetime:
+            mock_datetime.now.return_value = mock_date
+            result = json.loads(get_current_date())
+            assert result["success"] is True
+            assert result["date"] == "2025-06-15"
+
+    def test_get_current_date_different_dates(self):
+        """Should correctly format various dates."""
+        test_cases = [
+            (datetime(2024, 1, 1), "2024-01-01"),
+            (datetime(2025, 12, 31), "2025-12-31"),
+            (datetime(2026, 2, 17), "2026-02-17"),
+        ]
+        for mock_date, expected in test_cases:
+            with patch("tools.utility.datetime") as mock_datetime:
+                mock_datetime.now.return_value = mock_date
+                result = json.loads(get_current_date())
+                assert result["success"] is True
+                assert result["date"] == expected
+
+
+class TestLogInteraction:
+    """Tests for log_interaction tool."""
+
+    def test_log_interaction_success(self):
+        """Should return success message with logged path."""
+        with patch("tools.utility.log_chat") as mock_log_chat:
+            mock_log_chat.return_value = "Daily Notes/2025-06-15.md"
+            result = json.loads(
+                log_interaction(
+                    task_description="Test task",
+                    query="Test query",
+                    summary="Test summary",
+                )
+            )
+            assert result["success"] is True
+            assert "Logged to" in result["message"]
+            assert "Daily Notes/2025-06-15.md" in result["message"]
+
+    def test_log_interaction_with_files(self):
+        """Should pass files list to log_chat."""
+        with patch("tools.utility.log_chat") as mock_log_chat:
+            mock_log_chat.return_value = "Daily Notes/2025-06-15.md"
+            files = ["note1.md", "note2.md", "note3.md"]
+            result = json.loads(
+                log_interaction(
+                    task_description="Test task",
+                    query="Test query",
+                    summary="Test summary",
+                    files=files,
+                )
+            )
+            assert result["success"] is True
+            # Verify that log_chat was called with the files argument
+            mock_log_chat.assert_called_once_with(
+                "Test task", "Test query", "Test summary", files, None
+            )
+
+    def test_log_interaction_with_full_response(self):
+        """Should pass full_response to log_chat."""
+        with patch("tools.utility.log_chat") as mock_log_chat:
+            mock_log_chat.return_value = "Daily Notes/2025-06-15.md"
+            full_response = "This is the full conversational response."
+            result = json.loads(
+                log_interaction(
+                    task_description="Test task",
+                    query="Test query",
+                    summary="n/a",
+                    full_response=full_response,
+                )
+            )
+            assert result["success"] is True
+            # Verify that log_chat was called with the full_response argument
+            mock_log_chat.assert_called_once_with(
+                "Test task", "Test query", "n/a", None, full_response
+            )
+
+    def test_log_interaction_with_files_and_full_response(self):
+        """Should pass both files and full_response to log_chat."""
+        with patch("tools.utility.log_chat") as mock_log_chat:
+            mock_log_chat.return_value = "Daily Notes/2025-06-15.md"
+            files = ["file1.md", "file2.md"]
+            full_response = "Complete response text."
+            result = json.loads(
+                log_interaction(
+                    task_description="Research task",
+                    query="Find related notes",
+                    summary="n/a",
+                    files=files,
+                    full_response=full_response,
+                )
+            )
+            assert result["success"] is True
+            mock_log_chat.assert_called_once_with(
+                "Research task", "Find related notes", "n/a", files, full_response
+            )
+
+    def test_log_interaction_error(self):
+        """Should return error when log_chat raises an exception."""
+        with patch("tools.utility.log_chat") as mock_log_chat:
+            mock_log_chat.side_effect = ValueError("Vault path not found")
+            result = json.loads(
+                log_interaction(
+                    task_description="Test task",
+                    query="Test query",
+                    summary="Test summary",
+                )
+            )
+            assert result["success"] is False
+            assert "Logging failed" in result["error"]
+            assert "Vault path not found" in result["error"]
+
+    def test_log_interaction_error_various_exceptions(self):
+        """Should handle various exception types gracefully."""
+        exceptions = [
+            RuntimeError("Custom runtime error"),
+            IOError("File I/O error"),
+            Exception("Generic exception"),
+        ]
+        for exc in exceptions:
+            with patch("tools.utility.log_chat") as mock_log_chat:
+                mock_log_chat.side_effect = exc
+                result = json.loads(
+                    log_interaction(
+                        task_description="Test",
+                        query="Test",
+                        summary="Test",
+                    )
+                )
+                assert result["success"] is False
+                assert "Logging failed" in result["error"]


### PR DESCRIPTION
## Summary
- 9 new tests for `tools/utility.py`: get_current_date format/value, log_interaction success/error/optional params
- 18 new tests for `config.py`: env var defaults, custom values, clamping (MAX_SESSIONS, MAX_SESSION_MESSAGES), LLM_MODEL fallback, path resolution (relative/absolute CHROMA_PATH), derived paths (PREFERENCES_FILE, ATTACHMENTS_DIR)
- Config tests use `importlib.reload` with `dotenv.load_dotenv` patched out for proper isolation from `.env`
- Test count: 290 → 317

## Test plan
- [x] All 27 new tests pass
- [x] Full suite passes (317 tests)

Partial fix for #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)