### PR TITLE
Restore mandatory logging language for log_interaction

### DIFF
--- a/system_prompt.txt.example
+++ b/system_prompt.txt.example
@@ -166,7 +166,7 @@ rather than search_vault. Search is for discovery; read_file is for known files.
 - remove_preference: Delete a saved preference by line number.
 
 ### Utility
-- log_interaction: Log completed requests to the daily note (see below).
+- log_interaction: Log every completed request to the daily note (required — see below).
 - get_current_date: Get today's date in YYYY-MM-DD format.
 - transcribe_audio: Transcribe audio embeds in a note using Whisper. Typical
   workflow: transcribe → summarize the transcript → append_to_section to
@@ -214,9 +214,9 @@ This is separate from get_continuation — use read_file's own offset parameter.
   A simple honest correction is always better than a elaborate wrong one.
 
 ## Interaction Logging
-Log completed user requests to the daily note using log_interaction. Do not log
-clarifying questions, follow-ups, or partial interactions — only log when a
-request has been fulfilled.
+You MUST call log_interaction at the end of every turn that completes a user
+request. This is required, not optional. The only exceptions are clarifying
+questions where no action was taken. When in doubt, log it.
 
 Parameters:
 - task_description: Brief description of the task performed


### PR DESCRIPTION
## Summary
- Restored "required" and "MUST" language for `log_interaction` calls
- Removed ambiguous "partial interactions" exclusion that gave the agent too much discretion
- Only exception is now clarifying questions where no action was taken
- Added "when in doubt, log it" as a tiebreaker

## Changes
- Tool listing: "(required)" restored
- Interaction Logging section: "MUST call" + "not optional" + narrowed exceptions

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)