### PR TITLE
Add file-based logging with rotation

### DIFF
--- a/src/agent.py
+++ b/src/agent.py
@@ -15,7 +15,7 @@ from mcp import ClientSession, StdioServerParameters
 from mcp.client.stdio import stdio_client
 from openai import OpenAI
 
-from config import LLM_MODEL, PREFERENCES_FILE, VAULT_PATH
+from config import LLM_MODEL, PREFERENCES_FILE, VAULT_PATH, setup_logging
 from services.compaction import compact_tool_messages
 
 logger = logging.getLogger(__name__)
@@ -405,10 +405,7 @@ async def chat_loop():
 
 def main():
     """Entry point for the agent."""
-    logging.basicConfig(
-        level=logging.INFO,
-        format="%(asctime)s %(name)s %(levelname)s %(message)s",
-    )
+    setup_logging("agent")
     anyio.run(chat_loop)
 
 

--- a/src/api_server.py
+++ b/src/api_server.py
@@ -18,7 +18,7 @@ from mcp import ClientSession, StdioServerParameters
 from mcp.client.stdio import stdio_client
 from pydantic import BaseModel
 
-from config import API_PORT, MAX_SESSIONS, MAX_SESSION_MESSAGES
+from config import API_PORT, MAX_SESSIONS, MAX_SESSION_MESSAGES, setup_logging
 from services.compaction import compact_tool_messages
 from agent import (
     PROJECT_ROOT,
@@ -271,10 +271,7 @@ async def chat_stream(request: ChatRequest):
 
 def main():
     """Run the API server."""
-    logging.basicConfig(
-        level=logging.INFO,
-        format="%(asctime)s %(name)s %(levelname)s %(message)s",
-    )
+    setup_logging("api")
     uvicorn.run(
         "api_server:app",
         host="127.0.0.1",


### PR DESCRIPTION
## Summary
- Added `setup_logging()` in `config.py` — configures both stderr (for journalctl) and rotating file handler
- `api_server.py` logs to `logs/api.log`, `agent.py` logs to `logs/agent.log`
- Defaults: 5MB max per file, 3 backup files (configurable via `LOG_DIR`, `LOG_MAX_BYTES`, `LOG_BACKUP_COUNT`)
- `logs/` added to `.gitignore`
- 2 new tests for `setup_logging`

## Test plan
- [x] `test_setup_logging_creates_log_dir` — verifies directory and file creation, handler count
- [x] `test_setup_logging_writes_to_file` — verifies log messages appear in file
- [x] Full suite passes (319 tests)

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)