### PR TITLE
Accept dict or JSON string frontmatter in create_file

### DIFF
--- a/src/tools/files.py
+++ b/src/tools/files.py
@@ -65,7 +65,7 @@ def read_file(path: str, offset: int = 0, length: int = 3500) -> str:
 def create_file(
     path: str,
     content: str = "",
-    frontmatter: str | None = None,
+    frontmatter: dict | str | None = None,
 ) -> str:
     """Create a new markdown note in the vault.
 
@@ -73,8 +73,9 @@ def create_file(
         path: Path for the new file (relative to vault or absolute).
               Parent directories will be created if they don't exist.
         content: The body content of the note (markdown).
-        frontmatter: Optional YAML frontmatter as JSON string, e.g., '{"tags": ["meeting"]}'.
-                    Will be converted to YAML and wrapped in --- delimiters.
+        frontmatter: Optional frontmatter data. Prefer passing a native dict.
+            JSON string input is also supported for backwards compatibility.
+            Parsed data will be converted to YAML and wrapped in --- delimiters.
 
     Returns:
         Confirmation message or error.
@@ -91,11 +92,11 @@ def create_file(
     # Parse frontmatter if provided
     frontmatter_yaml = ""
     if frontmatter:
-        try:
-            fm_dict = json.loads(frontmatter)
-            frontmatter_yaml = yaml.dump(fm_dict, default_flow_style=False, allow_unicode=True)
-        except json.JSONDecodeError as e:
-            return err(f"Invalid frontmatter JSON: {e}")
+        fm_dict, parse_error = _parse_frontmatter(frontmatter)
+        if parse_error:
+            return err(parse_error)
+
+        frontmatter_yaml = yaml.dump(fm_dict, default_flow_style=False, allow_unicode=True)
 
     # Build file content
     if frontmatter_yaml:
@@ -114,6 +115,37 @@ def create_file(
 
     rel = str(get_relative_path(file_path))
     return ok(f"Created {rel}", path=rel)
+
+
+def _parse_frontmatter(frontmatter: dict | str | None) -> tuple[dict, str | None]:
+    """Normalize frontmatter input into a dictionary.
+
+    Accepts None, a native dict, or a JSON object string.
+    """
+    if frontmatter is None:
+        return {}, None
+
+    if isinstance(frontmatter, dict):
+        return frontmatter, None
+
+    if not isinstance(frontmatter, str):
+        return {}, (
+            "Invalid frontmatter type: expected dict, JSON object string, or null. "
+            f"Got {type(frontmatter).__name__}."
+        )
+
+    try:
+        parsed = json.loads(frontmatter)
+    except json.JSONDecodeError as e:
+        return {}, f"Invalid frontmatter JSON: {e}"
+
+    if not isinstance(parsed, dict):
+        return {}, (
+            "Invalid frontmatter JSON: expected a JSON object "
+            f"(e.g., {{\"tags\": [\"meeting\"]}}), got {type(parsed).__name__}."
+        )
+
+    return parsed, None
 
 
 def move_file(

--- a/tests/test_tools_files.py
+++ b/tests/test_tools_files.py
@@ -111,16 +111,30 @@ class TestCreateFile:
         content = (vault_config / "new_note.md").read_text()
         assert "# New Note" in content
 
-    def test_create_file_with_frontmatter(self, vault_config):
-        """Should create file with JSON frontmatter."""
+    def test_create_file_with_frontmatter_dict(self, vault_config):
+        """Should create file with native dict frontmatter."""
         result = json.loads(create_file(
-            "with_fm.md",
+            "with_fm_dict.md",
+            "Content",
+            frontmatter={"tags": ["test"], "status": "draft"}
+        ))
+        assert result["success"] is True
+
+        content = (vault_config / "with_fm_dict.md").read_text()
+        assert "---" in content
+        assert "tags:" in content
+        assert "test" in content
+
+    def test_create_file_with_frontmatter_json_string(self, vault_config):
+        """Should create file with JSON string frontmatter for backward compatibility."""
+        result = json.loads(create_file(
+            "with_fm_json.md",
             "Content",
             frontmatter='{"tags": ["test"], "status": "draft"}'
         ))
         assert result["success"] is True
 
-        content = (vault_config / "with_fm.md").read_text()
+        content = (vault_config / "with_fm_json.md").read_text()
         assert "---" in content
         assert "tags:" in content
         assert "test" in content
@@ -142,6 +156,12 @@ class TestCreateFile:
         result = json.loads(create_file("test.md", "content", frontmatter="not valid json"))
         assert result["success"] is False
         assert "invalid frontmatter json" in result["error"].lower()
+
+    def test_create_file_non_object_frontmatter_json(self, vault_config):
+        """Should return error when frontmatter JSON is not an object."""
+        result = json.loads(create_file("test.md", "content", frontmatter='["not", "an", "object"]'))
+        assert result["success"] is False
+        assert "expected a json object" in result["error"].lower()
 
 
 class TestMoveFile:


### PR DESCRIPTION
### Motivation
- Allow callers to pass native Python objects for frontmatter while preserving backwards compatibility with the existing JSON-string API.
- Provide clearer, actionable errors for invalid frontmatter inputs and reject non-object JSON values to avoid confusing YAML output.

### Description
- Change `create_file` signature to accept `frontmatter: dict | str | None` and update the docstring to prefer native `dict` input while keeping JSON-string compatibility.
- Add `_parse_frontmatter(frontmatter: dict | str | None) -> tuple[dict, str | None]` to normalize inputs, parse JSON strings, and return explicit errors for invalid JSON or non-object JSON values.
- Use the normalized dict directly with `yaml.dump` for frontmatter serialization and maintain the existing `ok(...)` / `err(...)` response envelope.
- Update `tests/test_tools_files.py` to add/adjust tests for native dict frontmatter, legacy JSON-string frontmatter, invalid JSON string, and non-object JSON frontmatter.

### Testing
- Ran `pytest` against `tests/test_tools_files.py`, but collection/execution could not complete in this environment due to setup issues: the default pyenv Python version configured in the repo was not available and `pytest` was not found for that selection, causing the first run to fail.
- Re-ran tests with `PYENV_VERSION=3.12.12 python -m pytest -q tests/test_tools_files.py`, which failed during test collection because the `yaml` module (`PyYAML`) is not installed in the test environment, producing `ModuleNotFoundError: No module named 'yaml'`.
- The new tests were added and are expected to pass once `pytest` and `PyYAML` are available in the execution environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995bc4cf6cc8322a4d58e6141db21f2)