### PR TITLE
Add shared pagination validation across paginated tools

### DIFF
--- a/src/tools/_validation.py
+++ b/src/tools/_validation.py
@@ -1,0 +1,41 @@
+"""Shared validation helpers for tool inputs."""
+
+
+def validate_pagination(
+    offset: int,
+    limit: int,
+    *,
+    max_limit: int = 500,
+) -> tuple[int | None, int | None, str | None]:
+    """Validate and coerce pagination parameters.
+
+    Args:
+        offset: Number of results to skip.
+        limit: Maximum number of results to return.
+        max_limit: Upper bound for limit to avoid huge payloads.
+
+    Returns:
+        Tuple of (coerced_offset, coerced_limit, error_message).
+        On error, offset/limit are None and error_message is populated.
+    """
+    try:
+        parsed_offset = int(offset)
+    except (TypeError, ValueError):
+        return None, None, "Invalid pagination: offset must be an integer"
+
+    try:
+        parsed_limit = int(limit)
+    except (TypeError, ValueError):
+        return None, None, "Invalid pagination: limit must be an integer"
+
+    if parsed_offset < 0:
+        return None, None, "Invalid pagination: offset must be >= 0"
+
+    if parsed_limit < 1:
+        return None, None, "Invalid pagination: limit must be >= 1"
+
+    if parsed_limit > max_limit:
+        return None, None, f"Invalid pagination: limit must be <= {max_limit}"
+
+    return parsed_offset, parsed_limit, None
+

--- a/tests/test_tools_links.py
+++ b/tests/test_tools_links.py
@@ -188,3 +188,22 @@ class TestListToolPagination:
         result = json.loads(find_outlinks("note1.md"))
         assert result["success"] is True
         assert "total" in result
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "expected_error"),
+    [
+        ({"offset": -1}, "offset must be >= 0"),
+        ({"limit": 0}, "limit must be >= 1"),
+        ({"limit": 501}, "limit must be <= 500"),
+    ],
+)
+def test_paginated_link_tools_reject_invalid_pagination(vault_config, kwargs, expected_error):
+    """Paginated links tools should return a consistent pagination validation error."""
+    backlinks = json.loads(find_backlinks("note1", **kwargs))
+    outlinks = json.loads(find_outlinks("note2.md", **kwargs))
+    folder = json.loads(search_by_folder(".", **kwargs))
+
+    for result in (backlinks, outlinks, folder):
+        assert result["success"] is False
+        assert expected_error in result["error"]


### PR DESCRIPTION
### Motivation
- Provide a single, consistent pagination validation/coercion helper so all paginated tools enforce the same constraints and error messages.
- Prevent invalid or overly-large `limit`/`offset` inputs from producing unexpected results or huge payloads by enforcing sane bounds.

### Description
- Added `validate_pagination` in `src/tools/_validation.py` which coerces `offset`/`limit` to integers and enforces `offset >= 0`, `limit >= 1`, and an upper bound `limit <= 500` by default, returning a unified `"Invalid pagination: ..."` error message on failure.
- Applied the helper to paginated link tools in `src/tools/links.py`: `find_backlinks`, `find_outlinks`, and `search_by_folder` now call `validate_pagination` before slicing results and use the returned `validated_offset`/`validated_limit`.
- Applied the helper to frontmatter tools in `src/tools/frontmatter.py`: `list_files_by_frontmatter` and `search_by_date_range` now validate pagination inputs and use the coerced values for paging.
- Added parametrized tests that exercise invalid pagination edge cases (`offset = -1`, `limit = 0`, `limit > 500`) to `tests/test_tools_links.py` and `tests/test_tools_frontmatter.py` which assert consistent `err(...)` responses.

### Testing
- Added unit tests in `tests/test_tools_links.py` and `tests/test_tools_frontmatter.py` to cover negative/zero/oversized pagination edge cases (these tests are present in the patch).
- Attempted to run the tests with `PYENV_VERSION=3.12.12 python -m pytest tests/test_tools_links.py tests/test_tools_frontmatter.py`, but test collection failed due to a missing environment dependency: `ModuleNotFoundError: No module named 'yaml'`; the new tests themselves have not been executed to completion in this environment.
- Once `PyYAML` (or the required testing deps) is available in the environment, running the above `pytest` command should validate the added pagination checks and expected error messages.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995bc5b77308322bfae8ac1269e2b00)