### PR TITLE
Accept native JSON-compatible values for frontmatter updates

### DIFF
--- a/src/tools/frontmatter.py
+++ b/src/tools/frontmatter.py
@@ -33,11 +33,46 @@ def _get_field_ci(frontmatter: dict, field: str):
 
 
 _WIKILINK_RE = re.compile(r"\[\[([^\]|]+)(?:\|[^\]]+)?\]\]")
+_JSON_SCALAR_RE = re.compile(r"^-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?$")
+
+
+FrontmatterValue = str | int | float | bool | list | dict | None
 
 
 def _strip_wikilinks(text: str) -> str:
     """Strip wikilink brackets: '[[Foo|alias]]' → 'Foo', '[[Bar]]' → 'Bar'."""
     return _WIKILINK_RE.sub(r"\1", text)
+
+
+def _normalize_frontmatter_value(value: FrontmatterValue) -> FrontmatterValue:
+    """Normalize tool input while preserving legacy JSON-string support.
+
+    Native JSON-compatible values are passed through unchanged.
+    String values are parsed as JSON only when they look like JSON containers
+    or scalar literals (quoted strings, numbers, true/false/null).
+    """
+    if not isinstance(value, str):
+        return value
+
+    candidate = value.strip()
+    if not candidate:
+        return value
+
+    looks_like_json = (
+        (candidate[0] == "{" and candidate[-1] == "}")
+        or (candidate[0] == "[" and candidate[-1] == "]")
+        or (candidate[0] == '"' and candidate[-1] == '"')
+        or candidate in ("true", "false", "null")
+        or bool(_JSON_SCALAR_RE.match(candidate))
+    )
+
+    if not looks_like_json:
+        return value
+
+    try:
+        return json.loads(candidate)
+    except (json.JSONDecodeError, TypeError):
+        return value
 
 
 def _matches_field(frontmatter: dict, field: str, value: str, match_type: str) -> bool:
@@ -201,7 +236,7 @@ def list_files_by_frontmatter(
 def update_frontmatter(
     path: str,
     field: str,
-    value: str | None = None,
+    value: FrontmatterValue = None,
     operation: str = "set",
 ) -> str:
     """Update frontmatter on a vault file.
@@ -209,7 +244,9 @@ def update_frontmatter(
     Args:
         path: Path to the note (relative to vault or absolute).
         field: Frontmatter field name to update.
-        value: Value to set. For lists, use JSON: '["tag1", "tag2"]'. Required for 'set'/'append'.
+        value: Value to set. Prefer native structured values (list/dict/bool/number/null)
+               when available. JSON strings are still accepted for compatibility.
+               Required for 'set'/'append'.
         operation: 'set' to add/modify, 'remove' to delete, 'append' to add to list.
 
     Returns:
@@ -221,13 +258,7 @@ def update_frontmatter(
     if operation in ("set", "append") and value is None:
         return err(f"value is required for '{operation}' operation")
 
-    # Parse value - try JSON first, fall back to string
-    parsed_value = value
-    if value is not None:
-        try:
-            parsed_value = json.loads(value)
-        except (json.JSONDecodeError, TypeError):
-            parsed_value = value  # Keep as string
+    parsed_value = _normalize_frontmatter_value(value)
 
     success, message = do_update_frontmatter(path, field, parsed_value, operation)
     if success:
@@ -237,7 +268,7 @@ def update_frontmatter(
 
 def batch_update_frontmatter(
     field: str,
-    value: str | None = None,
+    value: FrontmatterValue = None,
     operation: str = "set",
     paths: list[str] | None = None,
     target_field: str | None = None,
@@ -254,7 +285,9 @@ def batch_update_frontmatter(
 
     Args:
         field: Frontmatter field name to update.
-        value: Value to set. For lists, use JSON: '["tag1", "tag2"]'. Required for 'set'/'append'.
+        value: Value to set. Prefer native structured values (list/dict/bool/number/null)
+               when available. JSON strings are still accepted for compatibility.
+               Required for 'set'/'append'.
         operation: 'set' to add/modify, 'remove' to delete, 'append' to add to list.
         paths: List of file paths (relative to vault or absolute).
         target_field: Find files where this frontmatter field matches target_value.
@@ -319,13 +352,8 @@ def batch_update_frontmatter(
     else:
         return err("Provide either paths or target_field/target_value")
 
-    # Parse value once (same for all files)
-    parsed_value = value
-    if value is not None:
-        try:
-            parsed_value = json.loads(value)
-        except (json.JSONDecodeError, TypeError):
-            parsed_value = value
+    # Normalize value once (same for all files)
+    parsed_value = _normalize_frontmatter_value(value)
 
     # Process each file
     results = []

--- a/tests/test_tools_frontmatter.py
+++ b/tests/test_tools_frontmatter.py
@@ -10,6 +10,7 @@ from tools.frontmatter import (
     batch_update_frontmatter,
     list_files_by_frontmatter,
     search_by_date_range,
+    update_frontmatter,
 )
 
 
@@ -183,6 +184,126 @@ class TestBatchUpdateFrontmatter:
         assert "meeting" in fm["tags"]
         assert "important" in fm["tags"]
         assert "q1" in fm["tags"]
+
+    def test_batch_set_native_list_value(self, vault_config):
+        """Should accept a native list value without JSON string encoding."""
+        result = json.loads(
+            batch_update_frontmatter(
+                paths=["note2.md"],
+                field="tags",
+                value=["meeting", "important", "q2"],
+                operation="set",
+            )
+        )
+        assert result["success"] is True
+
+        import re
+        import yaml
+
+        content = (vault_config / "note2.md").read_text()
+        match = re.match(r"^---\n(.*?)\n---\n", content, re.DOTALL)
+        assert match
+        fm = yaml.safe_load(match.group(1))
+        assert fm["tags"] == ["meeting", "important", "q2"]
+
+    def test_batch_set_native_dict_value(self, vault_config):
+        """Should accept a native dict value without JSON string encoding."""
+        result = json.loads(
+            batch_update_frontmatter(
+                paths=["note1.md"],
+                field="metadata",
+                value={"owner": "alice", "priority": 2},
+                operation="set",
+            )
+        )
+        assert result["success"] is True
+
+        import re
+        import yaml
+
+        content = (vault_config / "note1.md").read_text()
+        match = re.match(r"^---\n(.*?)\n---\n", content, re.DOTALL)
+        assert match
+        fm = yaml.safe_load(match.group(1))
+        assert fm["metadata"] == {"owner": "alice", "priority": 2}
+
+    def test_batch_set_native_bool_value(self, vault_config):
+        """Should accept a native bool value without JSON string encoding."""
+        result = json.loads(
+            batch_update_frontmatter(
+                paths=["note1.md"],
+                field="published",
+                value=True,
+                operation="set",
+            )
+        )
+        assert result["success"] is True
+
+        import re
+        import yaml
+
+        content = (vault_config / "note1.md").read_text()
+        match = re.match(r"^---\n(.*?)\n---\n", content, re.DOTALL)
+        assert match
+        fm = yaml.safe_load(match.group(1))
+        assert fm["published"] is True
+
+
+class TestUpdateFrontmatterValueNormalization:
+    """Tests for update_frontmatter value normalization behavior."""
+
+    def test_update_frontmatter_accepts_native_bool(self, monkeypatch):
+        """Native boolean values should pass through unchanged."""
+        captured = {}
+
+        def fake_update(path, field, value, operation):
+            captured["value"] = value
+            return True, "ok"
+
+        monkeypatch.setattr("tools.frontmatter.do_update_frontmatter", fake_update)
+
+        result = json.loads(
+            update_frontmatter(path="note1.md", field="published", value=False, operation="set")
+        )
+        assert result["success"] is True
+        assert captured["value"] is False
+
+    def test_update_frontmatter_legacy_json_string_list(self, monkeypatch):
+        """Legacy JSON string containers should still be parsed."""
+        captured = {}
+
+        def fake_update(path, field, value, operation):
+            captured["value"] = value
+            return True, "ok"
+
+        monkeypatch.setattr("tools.frontmatter.do_update_frontmatter", fake_update)
+
+        result = json.loads(
+            update_frontmatter(
+                path="note1.md",
+                field="tags",
+                value='["a", "b"]',
+                operation="set",
+            )
+        )
+        assert result["success"] is True
+        assert captured["value"] == ["a", "b"]
+
+    def test_update_frontmatter_plain_string_remains_string(self, monkeypatch):
+        """Plain strings should not be treated as JSON."""
+        captured = {}
+
+        def fake_update(path, field, value, operation):
+            captured["value"] = value
+            return True, "ok"
+
+        monkeypatch.setattr("tools.frontmatter.do_update_frontmatter", fake_update)
+
+        result = json.loads(
+            update_frontmatter(path="note1.md", field="status", value="archived", operation="set")
+        )
+        assert result["success"] is True
+        assert captured["value"] == "archived"
 
 
 class TestCompoundFiltering:


### PR DESCRIPTION
### Motivation
- Update frontmatter update tools to accept native JSON-compatible Python types (list/dict/number/bool/null) in addition to legacy JSON-encoded strings to make tool calls more ergonomic and structured.
- Preserve backward compatibility so existing automation that passes JSON strings continues to work.

### Description
- Added a `FrontmatterValue` type alias and `_normalize_frontmatter_value` helper that passes native non-string values through and only attempts `json.loads` for string inputs that look like JSON containers or scalar literals.
- Replaced previous JSON-first parsing logic in both `update_frontmatter` and `batch_update_frontmatter` with the new normalization helper and broadened the `value` type hints to accept native types.
- Updated docstrings for both functions to recommend native structured arguments while retaining legacy JSON-string support.
- Added tests in `tests/test_tools_frontmatter.py` that cover native list/dict/bool inputs and legacy JSON-string behavior and added unit tests for `update_frontmatter` normalization behavior using `monkeypatch`.

### Testing
- Ran `pytest -q tests/test_tools_frontmatter.py` which failed in this environment because `pyenv` pointed to a missing Python version (`3.12.8`) and `pytest` was not available under that interpreter.
- Ran `PYENV_VERSION=3.12.12 python -m pytest -q tests/test_tools_frontmatter.py` which failed during collection due to a missing dependency (`yaml` / PyYAML) in the test environment.
- No automated test failures in repository code logic were observed; tests were added and committed, but full test execution could not complete here due to the environment dependency issues described above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995bc528fb8832295640284126ef0ab)