### PR TITLE
fix: narrow exception handling in four modules

### DIFF
--- a/src/hybrid_search.py
+++ b/src/hybrid_search.py
@@ -4,6 +4,8 @@
 import logging
 from collections import defaultdict
 
+from chromadb.errors import ChromaError
+
 from config import KEYWORD_LIMIT, RRF_K
 from services.chroma import get_collection
 
@@ -107,8 +109,8 @@ def keyword_search(
 
     try:
         matches = collection.get(**get_kwargs)
-    except Exception as e:
-        logger.warning(f"Keyword search failed: {e}")
+    except ChromaError as e:
+        logger.warning("Keyword search failed: %s", e)
         return []
 
     if not matches["ids"]:

--- a/src/index_vault.py
+++ b/src/index_vault.py
@@ -2,6 +2,7 @@
 """Index the Obsidian vault into ChromaDB for semantic search."""
 
 import hashlib
+import logging
 import os
 import re
 import sys
@@ -10,6 +11,8 @@ from datetime import datetime
 from pathlib import Path
 
 import yaml
+
+logger = logging.getLogger(__name__)
 
 from config import VAULT_PATH, CHROMA_PATH
 from services.chroma import get_collection
@@ -81,7 +84,8 @@ def _parse_frontmatter(text: str) -> dict:
         return {}
     try:
         return yaml.safe_load(text[4:end]) or {}
-    except Exception:
+    except yaml.YAMLError as e:
+        logger.debug("Invalid frontmatter YAML: %s", e)
         return {}
 
 

--- a/src/services/vault.py
+++ b/src/services/vault.py
@@ -1,6 +1,7 @@
 """Vault service - path resolution, file scanning, and utility functions."""
 
 import json
+import logging
 import re
 import shutil
 from datetime import datetime
@@ -9,6 +10,8 @@ from pathlib import Path
 import yaml
 
 from config import BATCH_CONFIRM_THRESHOLD, EXCLUDED_DIRS, VAULT_PATH
+
+logger = logging.getLogger(__name__)
 
 
 # =============================================================================
@@ -200,7 +203,8 @@ def extract_frontmatter(file_path: Path) -> dict:
     """
     try:
         content = file_path.read_text(encoding="utf-8", errors="ignore")
-    except Exception:
+    except OSError as e:
+        logger.debug("Could not read frontmatter from %s: %s", file_path, e)
         return {}
 
     match = re.match(r"^---\n(.*?)\n---\n", content, re.DOTALL)

--- a/src/tools/links.py
+++ b/src/tools/links.py
@@ -1,8 +1,11 @@
 """Link tools - backlinks, outlinks, folder search."""
 
+import logging
 import re
 
 from config import EXCLUDED_DIRS
+
+logger = logging.getLogger(__name__)
 from services.vault import err, get_relative_path, get_vault_files, ok, resolve_dir, resolve_file
 from tools._validation import validate_pagination
 
@@ -47,7 +50,8 @@ def _scan_backlinks(note_name: str) -> list[str]:
     for md_file in get_vault_files():
         try:
             content = md_file.read_text(encoding="utf-8", errors="ignore")
-        except Exception:
+        except OSError as e:
+            logger.debug("Skipping %s during backlink scan: %s", md_file, e)
             continue
         if re.search(pattern, content, re.IGNORECASE):
             backlinks.append(get_relative_path(md_file))


### PR DESCRIPTION
## Summary
- Replace bare `except Exception` with specific types (`OSError`, `yaml.YAMLError`, `ChromaError`) in four locations
- Add `logger.debug`/`logger.warning` at all catch sites so errors are no longer silently swallowed
- Unexpected exceptions now propagate instead of being masked

## Test plan
- [x] All 412 existing tests pass
- [ ] Verify debug logging appears when a file read fails in vault.py or links.py
- [ ] Verify malformed YAML frontmatter logs a debug message during indexing

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)