### PR TITLE
fix: prevent accumulating blank lines in log_interaction

### DIFF
--- a/src/log_chat.py
+++ b/src/log_chat.py
@@ -140,9 +140,10 @@ def insert_entry(content: str, entry: str) -> str:
     if pos != -1:
         insert_pos = pos + len(marker)
         # Skip existing newlines after header
-        while insert_pos < len(content) and content[insert_pos] == '\n':
-            insert_pos += 1
-        content = content[:insert_pos] + "\n" + entry + content[insert_pos:]
+        rest_start = insert_pos
+        while rest_start < len(content) and content[rest_start] == '\n':
+            rest_start += 1
+        content = content[:insert_pos] + "\n" + entry + content[rest_start:]
     else:
         content += entry
     


### PR DESCRIPTION
## Summary
- Fixed `insert_entry` in `log_chat.py` which was adding an extra blank line between the `## Vault Agent Interactions` heading and entries on every call
- The bug: the while loop advanced `insert_pos` past existing newlines but `content[:insert_pos]` still included them, then prepended another `\n`
- Fix: use separate `rest_start` variable to skip newlines in the remainder without including them in the prefix slice
- Added 4 tests for `insert_entry` covering single insertion, repeated insertions (no accumulation), ordering, and fallback behavior

## Test plan
- [x] New `TestInsertEntry` tests verify no blank line accumulation
- [x] Full test suite passes (447 tests)

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)