### PR TITLE
fix: echo value in update_frontmatter success messages

### DIFF
--- a/src/services/vault.py
+++ b/src/services/vault.py
@@ -353,9 +353,9 @@ def do_update_frontmatter(
     if operation == "remove":
         return True, f"Removed '{field}' from {path}"
     elif operation == "append":
-        return True, f"Appended to '{field}' in {path}"
+        return True, f"Appended {parsed_value!r} to '{field}' in {path}"
     else:
-        return True, f"Set '{field}' in {path}"
+        return True, f"Set '{field}' to {parsed_value!r} in {path}"
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- `set` now returns: `Set 'category' to ['person', 'actor'] in path.md`
- `append` now returns: `Appended 'project' to 'tags' in path.md`
- Prevents LLM from retrying successful operations because it couldn't confirm the value was set correctly

## Test plan
- [x] All 447 tests pass (no tests asserted on exact message strings)

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)